### PR TITLE
Remove git tracking for node_modules (as per standard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/misc.xml
 .idea/misc.xml
 .idea/misc.xml
+
+node_modules


### PR DESCRIPTION
#### Description:
- Usually, full libraries / modules / submodules / etc. are not tracked or uploaded to git.
- This is also standard for npm. All you need to do is run `npm install` or `npm update` in the project root.